### PR TITLE
Add to list of valid chars in path_segment

### DIFF
--- a/lib/graphite/target_grammer.treetop
+++ b/lib/graphite/target_grammer.treetop
@@ -21,7 +21,7 @@ grammar TargetGrammer
   end
 
   rule path_segment
-    [a-zA-Z0-9_\*\-]+ <Graphite::TargetGrammer::PathSegment>
+    [a-zA-Z0-9_\[\]\{\}\*\-]+ <Graphite::TargetGrammer::PathSegment>
   end
 
   rule comment

--- a/spec/data/metrics.yml
+++ b/spec/data/metrics.yml
@@ -596,3 +596,4 @@
 - alias(transformNull(smartSummarize(stats_counts.merchant_center.jobs.roi.watson.watson_consumer_connect_mail_stats.updated, "10min", "sum")), "changed")
 - alias(hitcount(stats.monocle.indexer.deals.update.start,"10min"), "deals updates in 10 min period")
 - alias(stats.monocle.indexer.deals.update.start, "drawAsInfinite(update)")
+- averageSeriesWithWildcards(host.cpu-[0-7].cpu-{user,system}.value, 1)

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20131106162900) do
+ActiveRecord::Schema.define(version: 20140106161202) do
 
   create_table "applications", force: true do |t|
     t.integer  "user_id"
@@ -33,6 +33,8 @@ ActiveRecord::Schema.define(version: 20131106162900) do
     t.text     "data",       limit: 2147483647,             null: false
   end
 
+  add_index "job_data", ["job_id"], name: "index_job_data_on_job_id", using: :btree
+
   create_table "job_errors", force: true do |t|
     t.integer  "job_id"
     t.datetime "created_at"
@@ -43,6 +45,7 @@ ActiveRecord::Schema.define(version: 20131106162900) do
   end
 
   add_index "job_errors", ["job_id"], name: "job_id", using: :btree
+  add_index "job_errors", ["status"], name: "index_job_errors_on_status", using: :btree
 
   create_table "jobs", force: true do |t|
     t.datetime "created_at"
@@ -67,6 +70,7 @@ ActiveRecord::Schema.define(version: 20131106162900) do
 
   add_index "jobs", ["app_id"], name: "app_id", using: :btree
   add_index "jobs", ["id", "name"], name: "id_name_version_key", unique: true, using: :btree
+  add_index "jobs", ["status"], name: "index_jobs_on_status", using: :btree
   add_index "jobs", ["user_id"], name: "jobs_ibfk_1", using: :btree
 
   create_table "users", force: true do |t|

--- a/spec/lib/graphite/target_parser_spec.rb
+++ b/spec/lib/graphite/target_parser_spec.rb
@@ -63,7 +63,7 @@ describe Graphite::TargetParser do
 
   context 'expression' do
     context 'is parseable' do
-      it 'for all values in metrics.yml' do
+      it 'using comprehensive list of metrics in metrics.yml' do
         metrics = YAML.load_file("spec/data/metrics.yml")
         parser = Graphite::TargetParser.new
         metrics.each do |m|


### PR DESCRIPTION
Allow path segments like:

host.cpu-[0-7].cpu-{user,system}.value

Please note that the parser is not strict. For example it would allow:

host.cpu-][.cpu-}{.value

Fixes livingsocial/rearview#42

See:
http://graphite.readthedocs.org/en/0.9.10/functions.html#graphite.render.functions.averageSeriesWithWildcards
