### PR TITLE
Fix graphite client reachable? method

### DIFF
--- a/lib/graphite/client.rb
+++ b/lib/graphite/client.rb
@@ -35,7 +35,7 @@ module Graphite
       reachable = false
       begin
         response = connection.get('/render')
-        reachable = response.status==200 && response.headers['content-type'].include?('image/png') && response.headers['content-length'].to_i > 0
+        reachable = response.status==200 && response.headers['content-type'].include?('image/png') && response.body.length > 0
       rescue Exception => e
       end
       reachable

--- a/spec/lib/graphite/client_spec.rb
+++ b/spec/lib/graphite/client_spec.rb
@@ -94,24 +94,24 @@ describe Graphite::Client do
       end
       @client.stubs(:connection).returns(@connection_stub)
     end
-    it 'is true when response is 200, content is image/png, and content-length > 0' do
-      @request_stubs.get('/render') {[ 200, { 'content-type' => 'image/png', 'content-length' => '123' }, '' ]}
+    it 'is true when response is 200, content is image/png, and body length > 0' do
+      @request_stubs.get('/render') {[ 200, { 'content-type' => 'image/png', 'content-length' => '123' }, 'body' ]}
       expect(@client.reachable?).to be_true
     end
-    it 'is true when response is 200, content is "image/png; charset=bogus", and content-length > 0' do
-      @request_stubs.get('/render') {[ 200, { 'content-type' => 'image/png; charset=bogus', 'content-length' => '123' }, '' ]}
+    it 'is true when response is 200, content is "image/png; charset=bogus", and body length > 0' do
+      @request_stubs.get('/render') {[ 200, { 'content-type' => 'image/png; charset=bogus' }, 'body' ]}
       expect(@client.reachable?).to be_true
     end
     it 'is false when response is not 200' do
-      @request_stubs.get('/render') {[ 500, { }, '' ]}
+      @request_stubs.get('/render') {[ 500, { 'content-type' => 'image/png' }, 'body' ]}
       expect(@client.reachable?).to be_false
     end
     it 'is false when content-type is not image/png' do
-      @request_stubs.get('/render') {[ 200, { 'content-type' => 'text/html', 'content-length' => '123' }, '' ]}
+      @request_stubs.get('/render') {[ 200, { 'content-type' => 'text/html' }, 'body' ]}
       expect(@client.reachable?).to be_false
     end
-    it 'is false when content-length is 0' do
-      @request_stubs.get('/render') {[ 200, { 'content-type' => 'image/png', 'content-length' => '0' }, '' ]}
+    it 'is false when body length is 0' do
+      @request_stubs.get('/render') {[ 200, { 'content-type' => 'image/png' }, '' ]}
       expect(@client.reachable?).to be_false
     end
   end


### PR DESCRIPTION
Was checking for non-zero content-length header, but this doesn't take
into account chunked encoding. Changed to check for body length > 0

Fixes livingsocial/rearview#44
